### PR TITLE
Partial auto refresh/HMR

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,6 +6,12 @@
       "env": {
         "node": true
       }
+    },
+    {
+      "files": ["hmrClient/client.js"],
+      "env": {
+        "browser": true
+      }
     }
   ]
 }

--- a/hmrClient/client.js
+++ b/hmrClient/client.js
@@ -1,0 +1,34 @@
+function replacePartial(partialName, newContent) {
+  const startMarkers = document.querySelectorAll(
+    `template[data-vite-handlebars-partial-marker='start'][data-vite-handlebars-partial-name='${partialName}']`
+  );
+
+  for (const startMarker of startMarkers) {
+    let currentElement = startMarker.nextSibling;
+    let foundEndMarker = false;
+    // Transverse through the DOM removing each element until we find the end marker
+    while (!foundEndMarker) {
+      if (
+        currentElement?.getAttribute?.('data-vite-handlebars-partial-marker') === 'end' &&
+        currentElement?.getAttribute?.('data-vite-handlebars-partial-name') === partialName
+      ) {
+        foundEndMarker = true;
+      } else {
+        const previousElement = currentElement;
+        currentElement = previousElement.nextSibling;
+        previousElement.remove();
+      }
+    }
+
+    // Once the end marker is found we need to insert the new content
+    // We're injecting trusted content so can safely ignore the eslint warning
+    // eslint-disable-next-line no-unsanitized/property
+    startMarker.outerHTML = startMarker.outerHTML + newContent;
+  }
+}
+
+if (import.meta.hot) {
+  import.meta.hot.on('plugin-handlebars-partial-update', (data) => {
+    replacePartial(data.partialName, data.content); // Specifically using `childNodes` because `children` does not include text nodes it seems
+  });
+}

--- a/hmrClient/client.js
+++ b/hmrClient/client.js
@@ -29,6 +29,6 @@ function replacePartial(partialName, newContent) {
 
 if (import.meta.hot) {
   import.meta.hot.on('plugin-handlebars-partial-update', (data) => {
-    replacePartial(data.partialName, data.content); // Specifically using `childNodes` because `children` does not include text nodes it seems
+    replacePartial(data.partialName, data.content);
   });
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "microbundle -f es,cjs --target node --no-compress",
+    "build": "yarn run build:plugin && yarn run build:hmrClient",
+    "build:plugin": "microbundle -f es,cjs --target node --no-compress",
+    "build:hmrClient": "microbundle -i hmrClient/client.js -o dist/hmrClient.js --no-pkg-main --no-sourcemap -f modern --no-compress --target web",
     "lint": "eslint .",
     "test": "jest",
     "release": "standard-version",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,8 @@
+export function escapeHtml(unsafe: string): string {
+  return unsafe
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
-import { compile, registerHelper, RuntimeOptions } from 'handlebars';
-import { resolve } from 'path';
-import { Plugin as VitePlugin } from 'vite';
+import {
+  compile,
+  registerHelper,
+  RuntimeOptions,
+  partials as registeredPartials,
+} from 'handlebars';
+import { resolve, parse } from 'path';
+import { readFile } from 'fs/promises';
+import { IndexHtmlTransformResult, Plugin as VitePlugin, TransformResult } from 'vite';
 import { registerPartials } from './partials';
 
 type CompileArguments = Parameters<typeof compile>;
@@ -20,10 +26,15 @@ export default function handlebars({
   partialDirectory,
 }: HandlebarsPluginConfig = {}): VitePlugin {
   let root: string;
+  const HMR_CLIENT_SCRIPT_PATH = '/@vite-plugin-handlebars/hmrClient.js';
 
   registerHelper('resolve-from-root', function (path) {
     return resolve(root, path);
   });
+
+  function compileAndGenerateTemplate(hbTemplateString: string) {
+    return compile(hbTemplateString, compileOptions)(context, runtimeOptions);
+  }
 
   return {
     name: 'handlebars',
@@ -32,20 +43,64 @@ export default function handlebars({
       root = config.root;
     },
 
+    resolveId(id) {
+      if (id === HMR_CLIENT_SCRIPT_PATH) {
+        return HMR_CLIENT_SCRIPT_PATH;
+      }
+    },
+    async load(id) {
+      if (id === HMR_CLIENT_SCRIPT_PATH) {
+        // Returns the content of the compiled hmrClient/client.js
+        return readFile(__dirname + '/hmrClient.js').then((content) => content.toString());
+      }
+    },
+
+    async handleHotUpdate({ server, file, read }) {
+      const partialName = parse(file).name;
+
+      // handleHotUpdate gets called for any changes in project dir so we need to verify
+      // that it is a file we care about
+      if (registeredPartials[partialName]) {
+        // TODO: This could be problematic because we aren't checking if
+        //  this file is actually one of our partial files.
+        //  So a file with the same name could be mistaken
+        server.ws.send({
+          type: 'custom',
+          event: 'plugin-handlebars-partial-update',
+          data: {
+            partialName: partialName,
+            content: compileAndGenerateTemplate(await read()),
+          },
+        });
+      }
+
+      return [];
+    },
+
     transformIndexHtml: {
       // Ensure Handlebars runs _before_ any bundling
       enforce: 'pre',
 
-      async transform(html: string): Promise<string> {
+      async transform(html: string): Promise<IndexHtmlTransformResult> {
         if (partialDirectory) {
-          await registerPartials(partialDirectory);
+          await registerPartials(partialDirectory, process.env.NODE_ENV !== 'production');
         }
 
-        const template = compile(html, compileOptions);
-
-        const result = template(context, runtimeOptions);
-
-        return result;
+        return {
+          html: compileAndGenerateTemplate(html),
+          tags: partialDirectory // Only inject partial HMR script if partials are enabled
+            ? [
+                {
+                  injectTo: 'body',
+                  tag: 'script',
+                  attrs: {
+                    type: 'module',
+                    src: HMR_CLIENT_SCRIPT_PATH,
+                  },
+                },
+              ]
+            : [],
+        };
       },
     },
   };

--- a/src/partials.ts
+++ b/src/partials.ts
@@ -2,11 +2,12 @@ import { registerPartial } from 'handlebars';
 import { Dir } from 'fs';
 import { opendir, readFile } from 'fs/promises';
 import { resolve, parse } from 'path';
+import { escapeHtml } from './helpers';
 
 /**
  * Registers each HTML file in a directory as Handlebars partial
  */
-export async function registerPartials(directoryPath: string): Promise<void> {
+export async function registerPartials(directoryPath: string, enableHmr: boolean): Promise<void> {
   let dir: Dir;
 
   try {
@@ -22,7 +23,16 @@ export async function registerPartials(directoryPath: string): Promise<void> {
       const partialName = parse(entry.name).name;
       const content = await readFile(fullPath);
 
-      registerPartial(partialName, content.toString());
+      // Only inject the partial markers if in dev mode
+      const partialInjectString = enableHmr
+        ? `<template data-vite-handlebars-partial-marker="start"
+            data-vite-handlebars-partial-name="${escapeHtml(partialName)}"></template>
+            ${content.toString()}
+            <template data-vite-handlebars-partial-marker="end"
+            data-vite-handlebars-partial-name="${escapeHtml(partialName)}"></template>`
+        : content.toString();
+
+      registerPartial(partialName, partialInjectString);
     }
   }
 }


### PR DESCRIPTION
Adds HMR support to allow partials to be auto refreshed when their content is changed.

Todo:
* Add config option to disable or change to full browser refresh
* Write tests

(More info: https://github.com/alexlafroscia/vite-plugin-handlebars/issues/2#issuecomment-800986651)