### PR TITLE
feat: reload page on partial change

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,23 @@ export default {
 };
 ```
 
+### Disabling Browser Refresh on Partial Change
+
+By default, any time a partial changes, your browser window will be full reloaded. If you want to disable this behavior, you can set `reloadOnPartialChange` to `false`:
+
+```javascript
+// vite.config.js
+import handlebars from 'vite-plugin-handlebars';
+
+export default {
+  plugins: [
+    handlebars({
+      reloadOnPartialChange: false,
+    }),
+  ],
+};
+```
+
 ## Built-In Helpers
 
 ### `resolve-from-root`

--- a/__tests__/helpers/build.ts
+++ b/__tests__/helpers/build.ts
@@ -1,4 +1,4 @@
-import { build as viteBuild } from 'vite';
+import { ViteDevServer, build as viteBuild, createServer } from 'vite';
 import handlebars, { HandlebarsPluginConfig } from '../../src/index';
 
 type BuildResult = ReturnType<typeof viteBuild>;
@@ -6,6 +6,19 @@ type BuildResult = ReturnType<typeof viteBuild>;
 export function build(root: string, config: HandlebarsPluginConfig = {}): BuildResult {
   return viteBuild({
     root,
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      write: false,
+    },
+    plugins: [handlebars(config)],
+  });
+}
+
+export function serve(root: string, config: HandlebarsPluginConfig = {}): Promise<ViteDevServer> {
+  return createServer({
+    root,
+    configFile: false,
     logLevel: 'silent',
     build: {
       write: false,

--- a/__tests__/helpers/index.ts
+++ b/__tests__/helpers/index.ts
@@ -1,2 +1,3 @@
 export * from './build';
 export * from './rollup';
+export * from './wait-for';

--- a/__tests__/helpers/wait-for.ts
+++ b/__tests__/helpers/wait-for.ts
@@ -1,0 +1,46 @@
+const futureTick = setTimeout;
+
+const TIMEOUTS = [0, 1, 2, 5, 7];
+const MAX_TIMEOUT = 10;
+
+export class TimeoutError extends Error {}
+
+type AssertionCallback = () => Promise<void> | void;
+type WaitForOptions = {
+  timeout?: number;
+};
+
+export async function waitFor(
+  assertionCallback: AssertionCallback,
+  { timeout = 1000 }: WaitForOptions = {}
+): Promise<void> {
+  const waitUntilTimeoutError = new TimeoutError('Condition not met within timeout');
+
+  return new Promise<void>((resolve, reject) => {
+    let time = 0;
+
+    function scheduleCheck(timeoutsIndex: number) {
+      let interval = TIMEOUTS[timeoutsIndex];
+      if (interval === undefined) {
+        interval = MAX_TIMEOUT;
+      }
+
+      futureTick(async function () {
+        time += interval;
+
+        try {
+          await assertionCallback();
+          resolve();
+        } catch (error) {
+          if (time < timeout) {
+            scheduleCheck(timeoutsIndex + 1);
+          } else {
+            reject(waitUntilTimeoutError);
+          }
+        }
+      }, interval);
+    }
+
+    scheduleCheck(0);
+  });
+}

--- a/__tests__/reload.ts
+++ b/__tests__/reload.ts
@@ -1,0 +1,100 @@
+import { Factory as FixtureFactory } from 'file-fixture-factory';
+import { serve, waitFor, TimeoutError } from './helpers';
+
+const factory = new FixtureFactory('vite-plugin-handlebars');
+
+afterAll(async () => {
+  await factory.disposeAll();
+});
+
+test('it sends a `full-reload` event when an `hbs` partial changes', async () => {
+  const temp = await factory.createStructure({
+    'index.html': '{{> foo }}',
+    partials: {
+      'foo.hbs': '<p>foo</p>',
+    },
+  });
+  const devServer = await serve(temp.dir, {
+    partialDirectory: temp.path('partials'),
+  });
+
+  devServer.ws.send = jest.fn();
+
+  // Fake the user visiting the index page to build it
+  await devServer.transformIndexHtml('/', await temp.read('index.html'));
+
+  await temp.write('partials/foo.hbs', '<p>bar</p>');
+
+  await waitFor(
+    () => {
+      expect(devServer.ws.send).toBeCalledWith({ type: 'full-reload' });
+    },
+    { timeout: 3000 }
+  );
+
+  await devServer.close();
+});
+
+test('it sends a `full-reload` event when an `html` partial changes', async () => {
+  const temp = await factory.createStructure({
+    'index.html': '{{> foo }}',
+    partials: {
+      'foo.html': '<p>foo</p>',
+    },
+  });
+  const devServer = await serve(temp.dir, {
+    partialDirectory: temp.path('partials'),
+  });
+
+  devServer.ws.send = jest.fn();
+
+  // Fake the user visiting the index page to build it
+  await devServer.transformIndexHtml('/', await temp.read('index.html'));
+
+  await temp.write('partials/foo.html', '<p>bar</p>');
+
+  await waitFor(
+    () => {
+      expect(devServer.ws.send).toBeCalledWith({ type: 'full-reload' });
+    },
+    { timeout: 3000 }
+  );
+
+  await devServer.close();
+});
+
+test('reloading the browser can be disabled', async () => {
+  // Exact number of assertions between `waitFor` and the thrown TimeoutError
+  expect.assertions(305);
+
+  const temp = await factory.createStructure({
+    'index.html': '{{> foo }}',
+    partials: {
+      'foo.hbs': '<p>foo</p>',
+    },
+  });
+  const devServer = await serve(temp.dir, {
+    reloadOnPartialChange: false,
+    partialDirectory: temp.path('partials'),
+  });
+
+  devServer.ws.send = jest.fn();
+
+  // Fake the user visiting the index page to build it
+  await devServer.transformIndexHtml('/', await temp.read('index.html'));
+
+  await temp.write('partials/foo.hbs', '<p>bar</p>');
+
+  try {
+    await waitFor(
+      () => {
+        expect(devServer.ws.send).toBeCalledWith({ type: 'full-reload' });
+      },
+      { timeout: 3000 }
+    );
+  } catch (e) {
+    expect(e).toBeInstanceOf(TimeoutError);
+  } finally {
+    await devServer.close();
+  }
+});

--- a/src/partials.ts
+++ b/src/partials.ts
@@ -20,7 +20,10 @@ async function* walk(dir: string): AsyncGenerator<string> {
 /**
  * Registers each HTML file in a directory as Handlebars partial
  */
-export async function registerPartials(directoryPath: string | Array<string>): Promise<void> {
+export async function registerPartials(
+  directoryPath: string | Array<string>,
+  partialsSet: Set<string>
+): Promise<void> {
   const pathArray: Array<string> = Array.isArray(directoryPath) ? directoryPath : [directoryPath];
 
   for await (const path of pathArray) {
@@ -31,6 +34,8 @@ export async function registerPartials(directoryPath: string | Array<string>): P
         if (VALID_EXTENSIONS.has(parsedPath.ext)) {
           const partialName = join(parsedPath.dir, parsedPath.name).replace(`${path}/`, '');
           const content = await readFile(fileName);
+
+          partialsSet.add(fileName);
 
           registerPartial(partialName, content.toString());
         }


### PR DESCRIPTION
cc: @jdf221

I took a stab at the simplified version of handling partial changes with a `full-reload` event, plus added a test for the behavior. We don't try to do anything to validate the changed file is actually a partial, and honestly I think that's probably fine. The worst-case scenario is that the page reloads when some other `.hbs` file is changed, which doesn't really seem like a big deal.

What do you think?

***

Builds on #31 