### PR TITLE
[fix] resolve-from-root on windows

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { compile, registerHelper, HelperDeclareSpec, RuntimeOptions } from 'handlebars';
 import { resolve } from 'path';
+import { platform } from 'os';
 import { IndexHtmlTransformContext, Plugin as VitePlugin, normalizePath } from 'vite';
 import { Context, resolveContext } from './context';
 import { registerPartials } from './partials';
@@ -30,7 +31,13 @@ export default function handlebars({
   let root: string;
 
   registerHelper('resolve-from-root', function (path) {
-    return resolve(root, path);
+    const resolvedPath = resolve(root, path);
+
+    if (platform() === 'win32') {
+      return '/' + resolvedPath;
+    }
+
+    return resolvedPath;
   });
 
   if (helpers) {


### PR DESCRIPTION
Our project wasn't running on a windows machine and I tracked it down to the fact a / was missing in front of the url. So the browser tried to load it through the filesystem, which failed..