### PR TITLE
fix: remove partial filename check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ export default function handlebars({
       root = config.root;
     },
 
-    async handleHotUpdate({ server, file }) {
-      if (reloadOnPartialChange && partialsSet.has(file)) {
+    async handleHotUpdate({ server }) {
+      if (reloadOnPartialChange) {
         server.ws.send({
           type: 'full-reload',
         });


### PR DESCRIPTION
Fix issue #249 when changes in partials does not trigger reloads on the server.

- The partial filename checks was removed