### PR TITLE
v2: publish typescript declarations

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
 
   "compilerOptions": {
-    "outDir": "dist"
+    "outDir": "dist",
+    "declaration": true
   }
 }


### PR DESCRIPTION
[v2 does not include TypeScript declarations](https://arethetypeswrong.github.io/?p=vite-plugin-handlebars%402.0.0) because they aren't being created. This PR enables `compilerOptions.declaration` to fix that. `*.d.ts` files are now created in `dist` and therefore published properly to npm.

Tested with `yarn pack`, published content is now:

```
dist/
├── context.d.ts
├── context.js
├── index.d.ts
├── index.js
├── partials.d.ts
└── partials.js
CHANGELOG.md
README.md
package.json
```