### PR TITLE
Added parameter so filename is included in the partial mapping

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export interface HandlebarsPluginConfig {
   compileOptions?: CompileOptions;
   runtimeOptions?: RuntimeOptions;
   partialDirectory?: string | Array<string>;
+  useFileNameForPartial?: boolean;
   helpers?: HelperDeclareSpec;
 }
 
@@ -24,6 +25,7 @@ export default function handlebars({
   compileOptions,
   runtimeOptions,
   partialDirectory,
+  useFileNameForPartial,
   helpers,
 }: HandlebarsPluginConfig = {}): VitePlugin {
   // Keep track of what partials are registered
@@ -62,7 +64,7 @@ export default function handlebars({
 
       async handler(html: string, ctx: IndexHtmlTransformContext): Promise<string> {
         if (partialDirectory) {
-          await registerPartials(partialDirectory, partialsSet);
+          await registerPartials(partialDirectory, partialsSet, useFileNameForPartial);
         }
 
         const template = hbs.compile(html, compileOptions);

--- a/src/partials.ts
+++ b/src/partials.ts
@@ -26,6 +26,7 @@ async function* walk(dir: string): AsyncGenerator<string> {
 export async function registerPartials(
   directoryPath: string | Array<string>,
   partialsSet: Set<string>,
+  useFileNameForPartial?: boolean,
 ): Promise<void> {
   const pathArray: Array<string> = Array.isArray(directoryPath) ? directoryPath : [directoryPath];
 
@@ -50,6 +51,10 @@ export async function registerPartials(
           partialsSet.add(fileName);
 
           hbs.registerPartial(partialName, content.toString());
+          // register the partial using just the file name if it isn't in the root of the partialDirectory i.e. it's not the same as the partial name
+          if (useFileNameForPartial && partialName !== parsedPath.name) {
+            hbs.registerPartial(parsedPath.name, content.toString());
+          }
         }
       }
     } catch (e) {


### PR DESCRIPTION
Added useFileNameForPartial to allow the partial to register with the full path and the filename.

Rationale:
Using the library with nested partials works well but it does become quite verbose especially when you are using partial blocks e.g.

Instance where there is a components folder with multiple sub folders all containing named components within a same named folder

{{#> core-components/wrapper/wrapper }}
inside
{{/core-components/wrapper/wrapper}}

The inclusion of this parameter will allow both the nested partial name and the filename only partial name to be registered, with the side-effect that any partials with the same filename will be will re-registered with the last instance found.