### PR TITLE
chore(deps): bump handlebars from ^4.7.6 to ^4.7.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### 2.0.1 (2026-04-13)
 
-### Bug Fixes
+### Security Fixes
 
 - bump `handlebars` from `^4.7.6` to `^4.7.9` to resolve a critical security issue
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 2.0.1 (2026-04-13)
+
+### Bug Fixes
+
+- bump `handlebars` from `^4.7.6` to `^4.7.9` to resolve a critical security issue
+
 ## [2.0.0](https://github.com/alexlafroscia/vite-plugin-handlebars/compare/v1.6.0...v2.0.0) (2024-01-06)
 
 ### ⚠ BREAKING CHANGES

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "postpack": "pinst --enable"
   },
   "dependencies": {
-    "handlebars": "^4.7.6",
+    "handlebars": "^4.7.9",
     "vite": "^5.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-handlebars",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Vite plugin for Handlebars support in HTML",
   "type": "module",
   "exports": "./dist/index.js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,6 +1692,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
+  dependencies:
+    minimist: "npm:^1.2.5"
+    neo-async: "npm:^2.6.2"
+    source-map: "npm:^0.6.1"
+    uglify-js: "npm:^3.1.4"
+    wordwrap: "npm:^1.0.0"
+  dependenciesMeta:
+    uglify-js:
+      optional: true
+  bin:
+    handlebars: bin/handlebars
+  checksum: 22f8105a7e68e81aff2662bb434edf05f757d21d850731d71cec886d69c10cd33d3c43e34b2892968ec62de8241611851d3d0674c8ef324ea3e01dc66262faa9
+  languageName: node
+  linkType: hard
+
 "hard-rejection@npm:^2.1.0":
   version: 2.1.0
   resolution: "hard-rejection@npm:2.1.0"
@@ -2495,7 +2513,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"neo-async@npm:^2.6.0":
+"neo-async@npm:^2.6.0, neo-async@npm:^2.6.2":
   version: 2.6.2
   resolution: "neo-async@npm:2.6.2"
   checksum: c2f5a604a54a8ec5438a342e1f356dff4bc33ccccdb6dc668d94fe8e5eccfc9d2c2eea6064b0967a767ba63b33763f51ccf2cd2441b461a7322656c1f06b3f5d
@@ -3907,7 +3925,7 @@ __metadata:
     "@tsconfig/node20": "npm:^20.1.2"
     "@types/node": "npm:^20.10.6"
     file-fixture-factory: "npm:^4.0.1"
-    handlebars: "npm:^4.7.6"
+    handlebars: "npm:^4.7.9"
     husky: "npm:^8.0.3"
     lint-staged: "npm:^15.2.0"
     pinst: "npm:^3.0.0"


### PR DESCRIPTION
See security issues https://github.com/handlebars-lang/handlebars.js/releases/tag/v4.7.9

[GHSA-2w6w-674q-4c4q](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-2w6w-674q-4c4q)
[GHSA-3mfm-83xf-c92r](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-3mfm-83xf-c92r)
[GHSA-xhpv-hc6g-r9c6](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-xhpv-hc6g-r9c6)
[GHSA-xjpj-3mr7-gcpf](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-xjpj-3mr7-gcpf)
[GHSA-9cx6-37pm-9jff](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-9cx6-37pm-9jff)
[GHSA-2qvq-rjwj-gvw9](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-2qvq-rjwj-gvw9)
[GHSA-7rx3-28cr-v5wh](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-7rx3-28cr-v5wh)
[GHSA-442j-39wm-28r2](https://github.com/handlebars-lang/handlebars.js/security/advisories/GHSA-442j-39wm-28r2)