### PR TITLE
Fix version constraint for peer dependency vite

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "handlebars": "^4.7.9"
   },
   "peerDependencies": {
-    "vite": "^5.0.0 ^6.0.0 ^7.0.0 ^8.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "devDependencies": {
     "@movable/prettier-config": "^0.3.6",


### PR DESCRIPTION
The change from #262 introduced a peer dependency in package.json to vite with version constraint "^5.0.0 ^6.0.0 ^7.0.0 ^8.0.0". It seems this is not valid syntax in npm. 

This PR changes it to "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" which should be valid syntax according to https://docs.npmjs.com/cli/v10/configuring-npm/package-json#dependencies.

This would fix #268 as I encountered the same problem. Merge would be appreciated to get the changes from #261.

Thx