### PR TITLE
chore: add npm package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "dist"
   ],
   "repository": "git@github.com:alexlafroscia/vite-plugin-handlebars.git",
+  "bugs": {
+    "url": "https://github.com/alexlafroscia/vite-plugin-handlebars/issues"
+  },
+  "homepage": "https://github.com/alexlafroscia/vite-plugin-handlebars#readme",
   "author": "Alex LaFroscia <alex@lafroscia.com>",
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
## Summary
- Add npm `bugs` metadata pointing to this repository's issue tracker.
- Add npm `homepage` metadata pointing to the README.

## Verification
- `node -e "const p=require('./package.json'); console.log(JSON.stringify({bugs:p.bugs, homepage:p.homepage}, null, 2))"`
- `git diff --check`

This is a metadata-only package manifest update.
